### PR TITLE
Jinja utility pack

### DIFF
--- a/stackstorm-jinja/actions/render_file.py
+++ b/stackstorm-jinja/actions/render_file.py
@@ -1,0 +1,62 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import six
+import os
+
+from st2common.runners.base_action import Action
+from st2client.client import Client
+from st2common.content import utils as content_utils
+from st2common.util import jinja as jinja_utils
+
+
+class FormatResultAction(Action):
+    def __init__(self, config=None, action_service=None):
+        super(FormatResultAction, self).__init__(config=config, action_service=action_service)
+        
+        api_url = os.environ.get('ST2_ACTION_API_URL', None)
+        token = os.environ.get('ST2_ACTION_AUTH_TOKEN', None)
+        
+        self.client = Client(api_url=api_url, token=token)
+        
+        self.jinja = jinja_utils.get_jinja_environment(allow_undefined=True)
+        self.jinja.tests['in'] = lambda item, list: item in list
+
+    def run(self, template_pack, template_path, context, include_execution, include_six):
+        if include_six:
+            context['six'] = six
+            
+        if include_execution:
+            execution = self._get_execution(include_execution)
+            context['__execution'] = execution
+        
+        pack_path = content_utils.get_pack_base_path(template_pack)
+        abs_template_path = os.path.abspath(os.path.join(pack_path, template_path)) 
+        
+        if not abs_template_path.startswith(pack_path):
+            raise ValueError('Template_path points to a file outside pack directory.')
+        
+        with open(abs_template_path, 'r') as f:
+            template = f.read()
+
+        return self.jinja.from_string(template).render(context)
+
+    def _get_execution(self, execution_id):
+        if not execution_id:
+            raise ValueError('Invalid execution_id provided.')
+        execution = self.client.liveactions.get_by_id(id=execution_id)
+        if not execution:
+            return None
+        return execution.to_dict()

--- a/stackstorm-jinja/actions/render_file.yaml
+++ b/stackstorm-jinja/actions/render_file.yaml
@@ -1,0 +1,25 @@
+---
+name: "render_file"
+runner_type: "run-python"
+description: "Render template"
+enabled: true
+entry_point: "render_file.py"
+parameters:
+  template_pack:
+    type: "string"
+    description: "Path to the template"
+    required: true
+  template_path:
+    type: "string"
+    description: "Path to the template"
+    required: true
+  context:
+    type: object
+    description: "Context to render"
+    default: {}
+  include_execution:
+    type: string
+    description: "Include execution of the certain id to jinja context as `__execution` property"
+  include_six:
+    type: boolean
+    default: true

--- a/stackstorm-jinja/pack.yaml
+++ b/stackstorm-jinja/pack.yaml
@@ -1,0 +1,8 @@
+name: jinja
+description: Jinja template engine
+keywords:
+ - jinja
+ - template
+version: 0.1.0
+author: StackStorm dev
+email: support@stackstorm.com


### PR DESCRIPTION
Parameter evaluation works good enough when you need to compose something small: error message, url, one-liner. But when you try to build something bigger like chatops response, build page for st2ci execution or an email, composing them inside a workflow or a rule may seem, well, excessive.

This pack (or the only action we have there) is supposed to fix that.

It allows you to define a template inside one of your packs and then render this template with a context of choice. It requires explicit pack name because you don't want to keep all your templates inside utility pack. It provides you with a way to embed execution inside the context without passing it through action parameters (the resulting execution would be enormous and ever growing). It allows you to add `six` library to the context because you want your workflows to continue to work when we finally switch to python3. If ever.