### PR TITLE
New pack - stackstorm-backups

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "stackstorm-backups"]
+	path = stackstorm-backups
+	url = https://github.com/EncoreTechnologies/stackstorm-backups


### PR DESCRIPTION
Migrating one of our internal packs to the public.

This pack is used to backup the StackStorm Postgres and MongoDB databases.