### PR TITLE
Update Circle CI build script to check submodules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,12 @@ jobs:
 
     steps:
       - checkout
+      # Download submodules for any PR which might add pack as a submodule
+      - run:
+          name: Checkout submodules
+          command: |
+            git submodule init
+            git submodule update --remote
       - run:
           name: Prepare repository
           command: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "stackstorm-influxdb"]
-	path = stackstorm-influxdb
-	url = https://github.com/EncoreTechnologies/stackstorm-influxdb.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "stackstorm-influxdb"]
+	path = stackstorm-influxdb
+	url = https://github.com/EncoreTechnologies/stackstorm-influxdb.git


### PR DESCRIPTION
@nmaludy reminded me (thanks!) that we should also take into account any PRs which add new pack as a submodule.

This pull request updates Circle CI build config to check out any submodules. It also adds a test submodule to test that the build works.