### PR TITLE
CI branch environment variable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: Download dependencies
           command: |
-            git clone -b master git@github.com:stackstorm-exchange/ci.git ~/ci
+            git clone -b ${CI_BRANCH} git@github.com:stackstorm-exchange/ci.git ~/ci
             ~/ci/.circle/dependencies
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: Download dependencies
           command: |
-            git clone -b ${CI_BRANCH} git@github.com:stackstorm-exchange/ci.git ~/ci
+            git clone -b ${CI_BRANCH:-master} git@github.com:stackstorm-exchange/ci.git ~/ci
             ~/ci/.circle/dependencies
       - run:
           name: Run tests


### PR DESCRIPTION
Instead of hardcoding the `master` branch as the branch to checkout when cloning the pack CI repository, use environment variables to set the branch name to checkout, and use Bash variable reference magic to maintain reverse compatibility.

This PR will make it easier and faster to troubleshoot and test [changes to the CI repository](https://github.com/StackStorm-Exchange/ci/pull/74) when pack CI fails. With this change, checking out a different branch of the `ci` repository for a pack CI run is as easy as setting the `CI_BRANCH` environment variable in CircleCI config and rerunning the workflow.

Note that this change will only apply to future packs that are forked off of this repository. It will not retroactively apply to packs that already exist before this is merged.