### PR TITLE
stackstorm faster with-items

### DIFF
--- a/stackstorm_withitems/README.md
+++ b/stackstorm_withitems/README.md
@@ -1,0 +1,61 @@
+# withitems Integration Pack
+
+StackStorm integration pack for faster `with-items` in orquesta workflows
+
+## Quick Start
+
+Run the following commands to install this pack and the install  on your StackStorm host:
+
+``` shell
+st2 pack install withitems
+st2 pack configure withitems
+```
+
+## Configuration
+
+Copy the example configuration in [withitems.example.yaml](./withitems.example.yaml)
+to `/opt/stackstorm/configs/withitems.yaml` and edit as required.
+
+* `st2api_key`- optional key for preventing token timeouts
+* `st2apiurl` - url for api
+* `st2authurl` - url for authentication
+* `st2baseurl` - url for base stackstorm api
+
+### Configuration Example
+
+The configuration below is an example of what a end-user config might look like.
+``` yaml
+st2api_key: null
+st2apiurl: https://localhost:443/api
+st2authurl: https://localhost:443/auth
+st2baseurl: https://localhost:443
+```
+
+## Actions
+
+* `withitems.with_items`
+
+
+### Action workflow Example - withitems.with_items
+with_items will be used inside a workflow.  Here is an example of that. The YAQL select function is very handy to format a list of objects to pass as a parameter.
+``` shell
+---    
+    version: 1.0 
+    
+    description: A with items example
+    
+    input:
+      - list_items
+    
+    tasks:
+      task1:
+        action: withitems.with_items
+        input:
+          action: core.echo
+          parameters: "<% ctx().list_items.select({\"message\"=>concat(\"message \", $)}) %>"
+        next:
+          - when: <% succeeded() %>
+            do: task2
+      task2:
+        action: core.noop
+```

--- a/stackstorm_withitems/actions/with_items.py
+++ b/stackstorm_withitems/actions/with_items.py
@@ -11,7 +11,6 @@ from st2client.client import Client
 from st2client.commands import action as st2action
 from st2common.runners.base_action import Action
 
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 JINJA_REGEXP = '({{(.*?)}})'
 

--- a/stackstorm_withitems/actions/with_items.py
+++ b/stackstorm_withitems/actions/with_items.py
@@ -1,0 +1,144 @@
+import copy
+import jinja2
+import re
+import os
+import six
+import time
+import urllib3
+
+from st2client.models import LiveAction
+from st2client.client import Client
+from st2client.commands import action as st2action
+from st2common.runners.base_action import Action
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+JINJA_REGEXP = '({{(.*?)}})'
+
+class WithItemsAction(Action):
+
+    def __init__(self, config):
+        super(WithItemsAction, self).__init__(config)
+        self.jinja_env = jinja2.Environment()
+        self.jinja_pattern = re.compile(JINJA_REGEXP)
+        self.api_key = self.config.get("st2api_key", None)
+
+        if self.api_key is not None:
+            if os.environ.get("ST2_AUTH_TOKEN", None) is not None:
+                del os.environ["ST2_AUTH_TOKEN"]
+        self.client = Client(base_url=config["st2baseurl"],
+                auth_url=config["st2authurl"],
+                api_key=self.api_key,
+                api_url=config["st2apiurl"]
+                )
+
+    def unescape_jinja(self, expr):
+        if isinstance(expr, six.string_types):
+            return self.unescape_jinja_str(expr)
+        elif isinstance(expr, list):
+            return self.unescape_jinja_list(expr)
+        elif isinstance(expr, dict):
+            return self.unescape_jinja_dict(expr)
+        else:
+            raise TypeError("Unable to escape jinja expression for type: {var}".format(var=str(type(expr))))
+
+    def unescape_jinja_str(self, expr_str):
+        expr_str = expr_str.replace("{_{", "{{")
+        expr_str = expr_str.replace("}_}", "}}")
+        return expr_str
+
+    def unescape_jinja_list(self, expr_list):
+        return [self.unescape_jinja(expr) for expr in expr_list ]
+
+    def unescape_jinja_dict(self, expr_dict):
+        for k, v in six.iteritems(expr_dict):
+            expr_dict[k] = self.unescape_jinja(v)
+        return expr_dict
+
+    def render_jinja(self, context, expr):
+        if isinstance(expr, six.string_types):
+            return self.render_jinja_str(context, expr)
+        elif isinstance(expr, list):
+            return self.render_jinja_list(context, expr)
+        elif isinstance(expr, dict):
+            return self.render_jinja_dict(context, expr)
+        else:
+            raise TypeError("Unable to render Jinja expression for type: {}".format(type(expr)))
+
+    def render_jinja_str(self, context, expr_str):
+        # find all of the jinja patterns in expr_str
+        patterns = self.jinja_pattern.findall(expr_str)
+
+        # if the matched pattern matches the full expression, then pull out
+        # the first group [0][1] which is the content between the {{ }}
+        # then use this special rendering method
+        if patterns[0][0] == expr_str:
+            # we only have a single pattern, render it so that a native type
+            # will be returned
+            func = self.jinja_env.compile_expression(patterns[0][1], expr_str)
+            return func(**context)
+        else:
+            # we have multiple patterns in one string so rendering it
+            # "normallY" and this will return a string
+            template = self.jinja_env.from_string(expr_str)
+            return template.render(context)
+
+    def render_jinja_list(self, context, expr_list):
+        return [self.render_jinja(context, expr) for expr in expr_list]
+
+    def render_jinja_dict(self, context, expr_dict):
+        rendered = {}
+        for k, expr in six.iteritems(expr_dict):
+            rendered[k] = self.render_jinja(context, expr)
+        return rendered
+
+    def run(self, action, parameters, paging_limit, sleep_time, result=None, **kwargs):
+        # unescape jinja
+        result_expr = result
+        if result_expr:
+            result_expr = self.unescape_jinja(result_expr)
+
+        running_ids = []
+        finished = []
+        param_index = 0
+        success = True
+        while len(finished) < len(parameters):
+            # fill paging pool
+            while len(running_ids) < paging_limit and \
+                    len(parameters) != len(running_ids) + len(finished) : # end of list no more to page
+                self.logger.debug("creating action index: " + str(param_index))
+                execution = self.client.executions.create(
+                    LiveAction(action=action,
+                               parameters=parameters[param_index]))
+                running_ids.append(execution.id)
+                param_index+=1
+
+            # sleep and wait for some work to be done
+            time.sleep(sleep_time)
+
+            # check for completed or failures
+            execution_list = self.client.liveactions.query(id=",".join(running_ids))
+            for e_updated in execution_list:
+                if e_updated.status in st2action.LIVEACTION_COMPLETED_STATES:
+                    if e_updated.status != st2action.LIVEACTION_STATUS_SUCCEEDED:
+                        success = False
+                    self.logger.debug("finished execution: " + str(e_updated.id))
+                    running_ids.remove(e_updated.id)
+                    finished.append(e_updated)
+
+        # extract the information out of the output
+        outputs = []
+        for exe in finished:
+            outputs.append({"status": copy.deepcopy(exe.status),
+                            "result": copy.deepcopy(exe.__dict__["result"])})
+        results = []
+        if result_expr:
+            for output in outputs:
+                result = output["result"]
+                result_context = {"_": {"result": result}}
+                result = self.render_jinja(result_context, result_expr)
+                results.append(result)
+        else:
+            results = outputs
+
+        return (success, results)

--- a/stackstorm_withitems/actions/with_items.yaml
+++ b/stackstorm_withitems/actions/with_items.yaml
@@ -1,0 +1,29 @@
+---
+name: "with_items"
+runner_type: "python-script"
+description: "faster with items;"
+enabled: true
+entry_point: "with_items.py"
+parameters:
+  action:
+    type: string
+    required: true
+  parameters:
+    type: array
+    items:
+      type: object
+    description: "list of objects for parameters"
+  paging_limit:
+    type: integer
+    default: 5
+  sleep_time:
+    type: integer
+    default: 25
+  result:
+    type: string
+    description: "jinja string to {_{ _.result.xxx }_} portion of result to return"
+output_schema:
+  results:
+    type: "array"
+    items:
+      type: "object"

--- a/stackstorm_withitems/actions/with_sample.meta.yaml
+++ b/stackstorm_withitems/actions/with_sample.meta.yaml
@@ -1,0 +1,12 @@
+---
+name: "with_sample"
+runner_type: "orquesta"
+description: "sample with items workfly"
+enabled: true
+entry_point: workflows/with_sample.yaml
+parameters:
+  list_items:
+    type: array
+    items:
+      type: string 
+    default: ["1","2","3"]

--- a/stackstorm_withitems/actions/with_sample.meta.yaml
+++ b/stackstorm_withitems/actions/with_sample.meta.yaml
@@ -1,7 +1,7 @@
 ---
 name: "with_sample"
 runner_type: "orquesta"
-description: "sample with items workfly"
+description: "sample with items workflow"
 enabled: true
 entry_point: workflows/with_sample.yaml
 parameters:

--- a/stackstorm_withitems/actions/workflows/with_sample.yaml
+++ b/stackstorm_withitems/actions/workflows/with_sample.yaml
@@ -1,0 +1,19 @@
+version: 1.0
+
+description: A with items example
+
+input:
+  - list_items
+
+tasks:
+  task1:
+    action: withitems.with_items
+    input:
+      action: core.echo
+      parameters: "<% ctx().list_items.select({\"message\"=>concat(\"message \", $)}) %>"
+    next:
+      - when: <% succeeded() %>
+        do: task2
+  task2:
+    action: core.noop
+

--- a/stackstorm_withitems/config.schema.yaml
+++ b/stackstorm_withitems/config.schema.yaml
@@ -1,0 +1,18 @@
+---
+  st2baseurl:
+    description: "base host url for st2 api"
+    type: "string"
+    default: "http://localhost"
+  st2authurl:
+    description: "auth url for st2 api"
+    type: "string"
+    default: "http://localhost/auth"
+  st2apiurl:
+    description: "api url for st2 api"
+    type: "string"
+    default: "http://localhost/api"
+  st2api_key:
+    description: "api key used by stackstorm actions create with_items"
+    type: string
+    secret: true
+    required: false

--- a/stackstorm_withitems/pack.yaml
+++ b/stackstorm_withitems/pack.yaml
@@ -1,0 +1,9 @@
+---
+ref: withitems 
+name: withitems 
+description: faster with items
+version: 0.1.0
+author: Aaron Jonen, Nick Maludy
+email: aaron.jonen@cypherint.com
+python_versions:
+  - "3"

--- a/stackstorm_withitems/tests/unit_test_with_items.py
+++ b/stackstorm_withitems/tests/unit_test_with_items.py
@@ -1,0 +1,105 @@
+from st2tests.base import BaseActionTestCase
+from st2client.commands import action as st2action
+from with_items import WithItemsAction
+import mock
+
+def mock_sleep(time):
+    pass
+
+class ActionMockStatus(object):
+    def __init__(self, id, status):
+        self.status = status
+        self.id = str(id)
+        self.result = {"test":"OK"}
+
+
+class LiveActions(object):
+    def __init__(self, *args, **kwargs):
+        self.execution_status = {}
+        self.actions = {}
+        self.action_id_counter = 0
+        self.actions_seen = {}
+    def query(self, id):
+        """
+        :param ids: list[str]
+        """
+        ids = [i for i in id.split(",")]
+        results = []
+        for id in ids:
+            if self.actions_seen.get(id, False) == True:
+                self.actions[id].status = st2action.LIVEACTION_STATUS_SUCCEEDED
+                results.append(self.actions[id])
+            if self.actions[id].status == st2action.LIVEACTION_STATUS_RUNNING:
+                self.actions_seen[id] = True
+                results.append(self.actions[id])
+        return results
+    def create(self, *args, **kwargs):
+        action = ActionMockStatus(self.action_id_counter,
+                st2action.LIVEACTION_STATUS_RUNNING)
+        self.action_id_counter += 1
+        self.actions[action.id] = action
+        return action
+
+
+class MockClient(object):
+    def __init__(self, *args, **kwargs):
+        self.mock_live_actions = LiveActions()
+        self.liveactions = self.mock_live_actions
+
+    @property
+    def executions(self):
+        return self.liveactions
+
+
+class WithItemsTestCase(BaseActionTestCase):
+    action_cls = WithItemsAction
+    CONFIG = {
+            "st2apiurl": "http://test/auth",
+            "st2baseurl": "http://test/",
+            "st2authurl": "http://test/auth"
+            }
+
+    def test_action_with_items_unescape_jinja(self):
+        list_jinja = ["{_{xxx}_}"]
+        dict_jinja = {"x":"{_{xxx}_}"}
+        str_jinja = "{_{ xxx }_}"
+        action = self.get_action_instance(config=WithItemsTestCase.CONFIG)
+        res = action.unescape_jinja(list_jinja)
+        self.assertEquals(["{{xxx}}"], res)
+        res = action.unescape_jinja(dict_jinja)
+        self.assertEquals({"x":"{{xxx}}"}, res)
+        res = action.unescape_jinja(str_jinja)
+        self.assertEquals("{{ xxx }}", res)
+
+    def test_action_with_items_render_jinja(self):
+        mock_result = {"test":1, "test2":2}
+        result_context = {"_":{"result": mock_result}}
+        action = self.get_action_instance(config=WithItemsTestCase.CONFIG)
+        res = action.render_jinja(result_context,
+                action.unescape_jinja_str("{_{ _.result.test2 }_}"))
+        self.assertEquals(2, res)
+
+    @mock.patch('with_items.Client')
+    @mock.patch('with_items.time')
+    def test_action_with_items_run(self, mock_time, mock_client):
+        mock_time.sleep.side_effect = mock_sleep
+        mock_client.side_effect = MockClient
+        action = self.get_action_instance(config=WithItemsTestCase.CONFIG)
+        list_params = [
+                {"value1":True},
+                {"value1":True},
+                {"value1":True},
+                {"value1":True},
+                {"value1":True},
+                {"value1":True},
+                {"value1":True},
+                {"value1":True},
+                {"value1":True},
+                {"value1":True}
+                ]
+        result = action.run(action="test.text",
+                parameters=list_params,
+                paging_limit=5,
+                sleep_time=0,
+                result_expr=None)
+        self.assertEquals(True, result[0])

--- a/stackstorm_withitems/withitems.example.yaml
+++ b/stackstorm_withitems/withitems.example.yaml
@@ -1,0 +1,4 @@
+st2api_key: null
+st2apiurl: https://localhost:443/api
+st2authurl: https://localhost:443/auth
+st2baseurl: https://localhost:443


### PR DESCRIPTION
Adds a pack and action to enable faster `with-items` in cases where the subworkflow or action does not contain an inquiry.  This effectively eliminates the subworkflow / actions history from being stored in the parent workflows context.  It results in speed gains due to mongodb write speeds on large context.