### PR TITLE
Use circleci/python:3.6 image in CircleCI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: Download dependencies
           command: |
-            git clone -b ${CI_BRANCH:-master} git@github.com:stackstorm-exchange/ci.git ~/ci
+            git clone -b ${CI_BRANCH:-master} git@github.com:StackStorm-Exchange/ci.git ~/ci
             ~/ci/.circle/dependencies
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build_and_test:
     docker:
-      - image: circleci/python:2.7
+      - image: circleci/python:3.6
       - image: rabbitmq:3
       - image: mongo:3.4
 


### PR DESCRIPTION
The CircleCI tests for StackStorm-Exchange/exchange-incubator#154 failed because it relied on the Python 3-only package [pyaoscx](https://github.com/aruba/pyaoscx) but the tests were running in a `circleci/python:2.7` container.

This PR updates the CI container to run in the most recent `circleci/python:3.6` image, since all future packs should support Python 3. And frankly, at this point I think all new packs should _only_ support Python 3, so I didn't even bother duplicating the workflow for Python 3.6, I just updated the existing workflow.