### PR TITLE
Bootstrap: Fix commentor permissions validation

### DIFF
--- a/.github/workflows/bootstrap_pack_from_pr.yaml
+++ b/.github/workflows/bootstrap_pack_from_pr.yaml
@@ -50,8 +50,6 @@ jobs:
       - name: Validate commentor can commit to incubator
         shell: bash
         env:
-          COMMENT_USER: ${{ github.comment.user.login }}
-          COMMENT_SENDER: ${{ github.sender.login }}
           VALID_ROLES: "admin maintain write"
         # the space before/after ROLE ensures we match the whole word
         run: >-

--- a/.github/workflows/bootstrap_pack_from_pr.yaml
+++ b/.github/workflows/bootstrap_pack_from_pr.yaml
@@ -46,13 +46,20 @@ jobs:
         env:
           VALID_ROLES: "admin maintain write"
         # the space before/after ROLE ensures we match the whole word
-        run: >-
-          export ROLE=$(
-          gh api '/repos/${{ github.repository }}/collaborators/${{ github.event.comment.user.login }}/permission'
-          --jq '.role_name'
+        run: |
+          export COMMENTOR_ROLE=$(
+            gh api -X GET \
+            '/repos/${{ github.repository }}/collaborators/${{ github.event.comment.user.login }}/permission' \
+            --jq '.role_name'
           )
-          && echo "ROLE=${ROLE}"
-          && [[ " ${VALID_ROLES} " =~ " ${ROLE} " ]]
+          echo "COMMENTOR_ROLE=${COMMENTOR_ROLE}"
+          if [[ " ${VALID_ROLES} " =~ " ${COMMENTOR_ROLE} " ]]; then
+            echo "Commentor bootstrap packs."
+          else
+            echo "Commentor may NOT bootstrap packs. '${COMMENTOR_ROLE}' is not one of: ${VALID_ROLES}"
+            echo "(ie the Commentor must have write access to ${{ github.repository }})."
+            exit 2
+          fi
 
       - name: Add eyes emoji reaction to say inspecting PR
         shell: bash
@@ -66,44 +73,55 @@ jobs:
     steps:
       - name: Make sure incubator PR is approved
         shell: bash
-        run: >-
+        run: |
           export APPROVED=$(
-          gh api /repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}/reviews
-          --jq '[.[] |
-          select(.author_association=="OWNER" or .author_association=="COLLABORATOR") |
-          select(.state=="APPROVED" or .state=="CHANGES_REQUESTED") |
-          .state == "APPROVED"] | (.|all) and (.|length>0)'
+            gh api -X GET \
+            '/repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}/reviews' \
+            --jq '[.[] | \
+            select(.author_association=="OWNER" or .author_association=="COLLABORATOR") | \
+            select(.state=="APPROVED" or .state=="CHANGES_REQUESTED") | \
+            .state == "APPROVED"] | (.|all) and (.|length>0)'
           )
-          && echo "APPROVED=${APPROVED}"
-          && [[ "${APPROVED}" == "true" ]]
+          echo "APPROVED=${APPROVED}"
+          if [[ "${APPROVED}" == "true" ]]; then
+            echo "Pack PR has been approved. Bootstrapping may continue."
+          else
+            echo "Pack PR has NOT been approved. Halting pack bootstrap!"
+            exit 3
+          fi
 
       - name: Make sure CI workflow is passing for PR
         shell: bash
         run: |
-          export CIRESULT=$(\
-          gh api graphql \
-          -F owner=${{ github.repository_owner }} \
-          -F repo=${{ github.event.repository.name }} \
-          -F pull_number=${{ github.event.issue.number }} \
-          -f query='query($owner: String!, $repo: String!, $pull_number: Int!) {
-            repository(owner: $owner, name:$repo) {
-              pullRequest(number:$pull_number) {
-                commits(last: 1) {
-                  nodes {
-                    commit {
-                      statusCheckRollup {
-                        state
+          export CIRESULT=$(
+            gh api graphql \
+            -F owner=${{ github.repository_owner }} \
+            -F repo=${{ github.event.repository.name }} \
+            -F pull_number=${{ github.event.issue.number }} \
+            -f query='query($owner: String!, $repo: String!, $pull_number: Int!) {
+              repository(owner: $owner, name:$repo) {
+                pullRequest(number:$pull_number) {
+                  commits(last: 1) {
+                    nodes {
+                      commit {
+                        statusCheckRollup {
+                          state
+                        }
                       }
                     }
                   }
                 }
               }
-            }
-          }' \
-          --jq '.data.repository.pullRequest.commits.nodes.[].commit.statusCheckRollup.state' \
-          ) \
-          && echo "CIRESULT=${CIRESULT}" \
-          && [[ "${CIRESULT}" == "SUCCESS" ]]
+            }' \
+            --jq '.data.repository.pullRequest.commits.nodes.[].commit.statusCheckRollup.state'
+          )
+          echo "CIRESULT=${CIRESULT}"
+          if [[ "${CIRESULT}" == "SUCCESS" ]]; then
+            echo "Pack CI has succeeded. Bootstrapping may continue."
+          else
+            echo "Pack CI has NOT succeeded. Halting pack bootstrap!"
+            exit 4
+          fi
 
       - name: Mark running with rocket reaction and label
         shell: bash

--- a/.github/workflows/bootstrap_pack_from_pr.yaml
+++ b/.github/workflows/bootstrap_pack_from_pr.yaml
@@ -64,7 +64,8 @@ jobs:
       - name: Add eyes emoji reaction to say inspecting PR
         shell: bash
         run: |
-          gh api -X POST -f content=eyes /repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions
+          gh api -X POST -f content=eyes \
+          '/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions'
 
   ready_to_merge_check:
     name: Check for Merge Readiness
@@ -126,8 +127,13 @@ jobs:
       - name: Mark running with rocket reaction and label
         shell: bash
         run: |
-          gh api -X POST -f content=rocket /repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions
-          jq -n '{"labels": ["bootstrap:in-progress"]}' | gh api -X POST /repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels --input -
+          gh api -X POST -f content=rocket \
+          '/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions'
+
+          jq -n '{"labels": ["bootstrap:in-progress"]}' | \
+          gh api -X POST \
+          '/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels' \
+          --input -
 
       - name: Publish status in incubator PR comment
         shell: bash
@@ -306,9 +312,16 @@ jobs:
       - name: Mark running with hooray reaction and label
         shell: bash
         run: |
-          gh api -X DELETE /repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/bootstrap:in-progress
-          gh api -X POST -f content=hooray /repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions
-          jq -n '{"labels": ["bootstrap:complete"]}' | gh api -X POST /repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels --input -
+          gh api -X DELETE \
+          '/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels/bootstrap:in-progress'
+
+          gh api -X POST -f content=hooray \
+          '/repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions'
+
+          jq -n '{"labels": ["bootstrap:complete"]}' |\
+          gh api -X POST \
+          '/repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels' \
+          --input -
 
       - name: Publish status in incubator PR comment
         shell: bash

--- a/.github/workflows/bootstrap_pack_from_pr.yaml
+++ b/.github/workflows/bootstrap_pack_from_pr.yaml
@@ -35,7 +35,7 @@ jobs:
     if: >-
       github.event.issue.pull_request
       && github.event.comment.body == '!bootstrap pack'
-    # Warning: using github.event.comment.author_association
+    # Warning: github.event.comment.author_association
     # cannot be used to check permissions
     # because it is NONE for some TSC members.
     runs-on: ubuntu-latest

--- a/.github/workflows/bootstrap_pack_from_pr.yaml
+++ b/.github/workflows/bootstrap_pack_from_pr.yaml
@@ -15,16 +15,19 @@ env:
   GH_TOKEN: ${{ github.token }}
 
 jobs:
-  debug:
-    name: Debug event
-    runs-on: ubuntu-latest
-    steps:
-      - name: print github.event
-        shell: bash
-        env:
-          GITHUB_EVENT: ${{ toJSON(github.event) }}
-        run: |
-          echo "${GITHUB_EVENT}"
+
+  # This job is very helpful in debugging why conditions don't match.
+  # To debug, uncomment this to inspect the event payload.
+  #debug:
+  #  name: Debug event
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #    - name: print github.event
+  #      shell: bash
+  #      env:
+  #        GITHUB_EVENT: ${{ toJSON(github.event) }}
+  #      run: |
+  #        echo "${GITHUB_EVENT}"
 
   permissions_check:
     name: Check Comment Author Permissions
@@ -35,14 +38,30 @@ jobs:
       github.event.comment.author_association == 'OWNER'
       || github.event.comment.author_association == 'MEMBER'
       || github.event.comment.author_association == 'COLLABORATOR'
+      || github.event.comment.author_association == 'CONTRIBUTOR'
       )
       && github.event.comment.body == '!bootstrap pack'
     # author_association enum def
     # https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
     runs-on: ubuntu-latest
     steps:
-      # the commentator has write access to the incubator
-      # so no more group membership validation required.
+      # TSC members can show up as "CONTRIBUTOR" which does not say
+      # that the commentor is an active TSC member, so double check.
+      - name: Validate commentor can commit to incubator
+        shell: bash
+        env:
+          COMMENT_USER: ${{ github.comment.user.login }}
+          COMMENT_SENDER: ${{ github.sender.login }}
+          VALID_ROLES: "admin maintain write"
+        # the space before/after ROLE ensures we match the whole word
+        run: >-
+          export ROLE=$(
+          gh api '/repos/${{ github.repository }}/collaborators/${{ github.event.comment.user.login }}/permission'
+          --jq '.role_name'
+          )
+          && echo "ROLE=${ROLE}"
+          && [[ " ${VALID_ROLES} " =~ " ${ROLE} " ]]
+
       - name: Add eyes emoji reaction to say inspecting PR
         shell: bash
         run: |

--- a/.github/workflows/bootstrap_pack_from_pr.yaml
+++ b/.github/workflows/bootstrap_pack_from_pr.yaml
@@ -34,20 +34,14 @@ jobs:
     # "!bootstrap pack" comment on pull requests
     if: >-
       github.event.issue.pull_request
-      && (
-      github.event.comment.author_association == 'OWNER'
-      || github.event.comment.author_association == 'MEMBER'
-      || github.event.comment.author_association == 'COLLABORATOR'
-      || github.event.comment.author_association == 'CONTRIBUTOR'
-      )
       && github.event.comment.body == '!bootstrap pack'
-    # author_association enum def
-    # https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
+    # Warning: using github.event.comment.author_association
+    # cannot be used to check permissions
+    # because it is NONE for some TSC members.
     runs-on: ubuntu-latest
     steps:
-      # TSC members can show up as "CONTRIBUTOR" which does not say
-      # that the commentor is an active TSC member, so double check.
-      - name: Validate commentor can commit to incubator
+      - name: Ensure the commentor is an active TSC member
+        # ie: Validate commentor can commit to incubator
         shell: bash
         env:
           VALID_ROLES: "admin maintain write"


### PR DESCRIPTION
It turns out I was testing as an admin while developing this workflow.
When I tried to trigger the bootstrap workflow under `StackStorm-Exchange`, however, I only have `maintain` permission as a member of the TSC. That shows up as a `CONTRIBUTOR`, so the permissions check inadvertently excluded me.

This adds another step to the workflow to make sure that the commentor can commit to the repository, which includes the TSC and any robots. Hopefully that covers all the TSC members - if anyone else finds another edge case (maybe a TSC member who has not made any commits in the incubator) we may have to further tune this check.
