### PR TITLE
Extra info on last message of bootstrap PR

### DIFF
--- a/.github/workflows/bootstrap_pack_from_pr.yaml
+++ b/.github/workflows/bootstrap_pack_from_pr.yaml
@@ -344,5 +344,6 @@ jobs:
             (4) wait for the next exchange index update (monitor updates [here](https://github.com/StackStorm-Exchange/index/actions))
             (5) once the index has updated, check out:
             ${{ needs.bootstrap_pack_repo.outputs.homepage }}
+            (6) Close WITHOUT merging this PR. DO NOT MERGE THIS PR.
         run: |
           gh pr comment '${{ github.event.issue.html_url }}' --body "${COMMENT}"


### PR DESCRIPTION
Action from last TSC meeting to add extra comment to the bootstrap PR process, so that we get notified to close without merging PR.