### PR TITLE
Fix py3.6 build by pinning the container to Ubuntu 20.04

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -12,7 +12,7 @@ jobs:
     # assuming that any pull requests from the same repo are infra changes.
     if: github.event.pull_request.head.repo.full_name != github.repository
 
-    # As long as we need Python 3.8 here in the test, we can only use up to Ubuntu 20
+    # As long as we need Python 3.6 here in the test, we can only use up to Ubuntu 20
     # See https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
     runs-on: ubuntu-20.04
     name: 'Build and Test / Python ${{ matrix.python-version-short }}'

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -10,8 +10,7 @@ jobs:
   build_and_test:
     # we only run if this is a pull request from a fork
     # assuming that any pull requests from the same repo are infra changes.
-    # Debug the build
-    #if: github.event.pull_request.head.repo.full_name != github.repository
+    if: github.event.pull_request.head.repo.full_name != github.repository
 
     # As long as we need Python 3.8 here in the test, we can only use up to Ubuntu 20
     # See https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
@@ -33,18 +32,18 @@ jobs:
           git submodule init
           git submodule update --remote
 
-      # - name: Prepare repository (incubator)
-      #   working-directory: pack
-      #   shell: bash
-      #   run: |
-      #     .scripts/prepare-repo.sh
+      - name: Prepare repository (incubator)
+        working-directory: pack
+        shell: bash
+        run: |
+          .scripts/prepare-repo.sh
 
-      # - name: Check for Apache 2.0 LICENSE file (required for new packs)
-      #   working-directory: pack
-      #   shell: bash
-      #   run: |
-      #     head -n3 LICENSE
-      #     grep -e 'Apache License' -e 2.0 LICENSE | grep -v -e APPENDIX -e attach
+      - name: Check for Apache 2.0 LICENSE file (required for new packs)
+        working-directory: pack
+        shell: bash
+        run: |
+          head -n3 LICENSE
+          grep -e 'Apache License' -e 2.0 LICENSE | grep -v -e APPENDIX -e attach
 
       - name: Install APT Dependencies
         uses: StackStorm-Exchange/ci/.github/actions/apt-dependencies@master

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -33,11 +33,11 @@ jobs:
           git submodule init
           git submodule update --remote
 
-      - name: Prepare repository (incubator)
-        working-directory: pack
-        shell: bash
-        run: |
-          .scripts/prepare-repo.sh
+      # - name: Prepare repository (incubator)
+      #   working-directory: pack
+      #   shell: bash
+      #   run: |
+      #     .scripts/prepare-repo.sh
 
       # - name: Check for Apache 2.0 LICENSE file (required for new packs)
       #   working-directory: pack

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -12,13 +12,15 @@ jobs:
     # assuming that any pull requests from the same repo are infra changes.
     if: github.event.pull_request.head.repo.full_name != github.repository
 
-    runs-on: ubuntu-latest
+    # As long as we need Python 3.8 here in the test, we can only use up to Ubuntu 20
+    # See https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
+    runs-on: ubuntu-20.04
     name: 'Build and Test / Python ${{ matrix.python-version-short }}'
     strategy:
       matrix:
         include:
           - python-version-short: "3.6"
-            python-version: 3.6.13
+            python-version: 3.6.15
     steps:
       - name: Checkout Pack Repo and CI Repos
         uses: StackStorm-Exchange/ci/.github/actions/checkout@master

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -10,7 +10,8 @@ jobs:
   build_and_test:
     # we only run if this is a pull request from a fork
     # assuming that any pull requests from the same repo are infra changes.
-    if: github.event.pull_request.head.repo.full_name != github.repository
+    # Debug the build
+    #if: github.event.pull_request.head.repo.full_name != github.repository
 
     # As long as we need Python 3.8 here in the test, we can only use up to Ubuntu 20
     # See https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
@@ -38,12 +39,12 @@ jobs:
         run: |
           .scripts/prepare-repo.sh
 
-      - name: Check for Apache 2.0 LICENSE file (required for new packs)
-        working-directory: pack
-        shell: bash
-        run: |
-          head -n3 LICENSE
-          grep -e 'Apache License' -e 2.0 LICENSE | grep -v -e APPENDIX -e attach
+      # - name: Check for Apache 2.0 LICENSE file (required for new packs)
+      #   working-directory: pack
+      #   shell: bash
+      #   run: |
+      #     head -n3 LICENSE
+      #     grep -e 'Apache License' -e 2.0 LICENSE | grep -v -e APPENDIX -e attach
 
       - name: Install APT Dependencies
         uses: StackStorm-Exchange/ci/.github/actions/apt-dependencies@master


### PR DESCRIPTION
An attempt to fix the [CI build](https://github.com/StackStorm-Exchange/exchange-incubator/actions/runs/5871242743/job/15920121017?pr=179#step:8:35) (failing on the new pack contribution https://github.com/StackStorm-Exchange/exchange-incubator/pull/179) 

```
Error: Version 3.6.13 with arch x64 not found
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```

It seems the py 3.6 is not available in the `ubuntu-latest` GHA container, - pin it to Ubuntu 20.4.